### PR TITLE
Fixing issue with default fields

### DIFF
--- a/mongoOperator/models/BaseModel.py
+++ b/mongoOperator/models/BaseModel.py
@@ -48,11 +48,7 @@ class BaseModel:
         """
         if not skip_validation:
             self.validate()
-        result = {}
-        for name, field in self.fields.items():
-            if self[name] is not None : # and not isinstance(self[name], Field):
-                result[name] = field.to_dict(self[name])
-        return result
+        return {name: field.to_dict(self[name], skip_validation=skip_validation) for name, field in self.fields.items()}
 
     def __eq__(self, other: any) -> bool:
         """

--- a/mongoOperator/models/BaseModel.py
+++ b/mongoOperator/models/BaseModel.py
@@ -6,7 +6,7 @@ import logging
 
 from typing import Dict
 
-from mongoOperator.models.fields import Field, pascal_to_lowercase
+from mongoOperator.models.fields import Field, lowercase_to_pascal
 
 
 class BaseModel:
@@ -22,13 +22,13 @@ class BaseModel:
         """
         self.fields = dict(inspect.getmembers(type(self), lambda f: isinstance(f, Field)))  # type: Dict[str, Field]
 
-        for field_name, value in kwargs.items():
+        for field_name, field in self.fields.items():
             # K8s API returns pascal cased strings, but we use lower-cased strings with underscores instead.
-            field_lower = pascal_to_lowercase(field_name)
-            if field_lower in self.fields:
-                setattr(self, field_lower, self.fields[field_lower].parse(value))
-            else:
-                logging.warning("The model %s does not have the %s field!", type(self), field_lower)
+            # we accept both in our models.
+            value = kwargs.get(field_name, kwargs.get(lowercase_to_pascal(field_name)))
+            if value is not None:
+                value = field.parse(value)
+            setattr(self, field_name, value)
 
     def validate(self) -> None:
         """
@@ -40,15 +40,17 @@ class BaseModel:
             except (ValueError, AttributeError) as err:
                 raise ValueError("Error for field {}: {}".format(repr(name), err))
 
-    def to_dict(self) -> Dict[str, any]:
+    def to_dict(self, skip_validation: bool = False) -> Dict[str, any]:
         """
         Returns a dictionary with the data of each field.
+        :param skip_validation: Whether the validation should be skipped.
         :return: A dict with the attribute name as key and the attribute value.
         """
-        self.validate()
+        if not skip_validation:
+            self.validate()
         result = {}
         for name, field in self.fields.items():
-            if self[name] is not None:
+            if self[name] is not None : # and not isinstance(self[name], Field):
                 result[name] = field.to_dict(self[name])
         return result
 
@@ -75,5 +77,7 @@ class BaseModel:
         Shows the string-representation of this object.
         :return: The object as string.
         """
-        return "{}({})".format(self.__class__.__name__,
-                               ", ".join('{}={}'.format(attr, value) for attr, value in self.to_dict().items()))
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join('{}={}'.format(attr, value) for attr, value in self.to_dict(skip_validation=True).items())
+        )

--- a/mongoOperator/models/fields.py
+++ b/mongoOperator/models/fields.py
@@ -53,13 +53,15 @@ class Field:
         self.validate(value)
         return value
 
-    def to_dict(self, value) -> any:
+    def to_dict(self, value, skip_validation: bool = False) -> any:
         """
         Returns a the value of this field as it should be set in the model dictionaries.
         :param value: The value to be converted.
+        :param skip_validation: Whether the validation should be skipped.
         :return: The value of this field.
         """
-        self.validate(value)
+        if not skip_validation:
+            self.validate(value)
         return value
 
 
@@ -90,13 +92,13 @@ class EmbeddedField(Field):
                 values = {pascal_to_lowercase(field_name): field_value for field_name, field_value in value.items()}
                 value = self.field_type(**values)
             except TypeError as err:
-                raise ValueError("Invalid values passed to field {}: {}. Received {}."
+                raise ValueError("Invalid values passed to {} field: {}. Received {}."
                                  .format(self.field_type.__name__, err, value))
         return super().parse(value)
 
-    def to_dict(self, value) -> Optional[Dict[str, any]]:
-        self.validate(value)
-        if value is None or isinstance(value, Field):
+    def to_dict(self, value, skip_validation: bool = False) -> Optional[Dict[str, any]]:
+        value = super().to_dict(value, skip_validation)
+        if value is None:
             return None
         return {k: v for k, v in value.to_dict().items() if v is not None}
 

--- a/mongoOperator/models/fields.py
+++ b/mongoOperator/models/fields.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Ultimaker
 # !/usr/bin/env python
 # -*- coding: utf-8 -*-
-from typing import Dict, Type
+from typing import Dict, Type, Optional
 
 import re
 
@@ -15,6 +15,17 @@ def pascal_to_lowercase(value: str) -> str:
     :return: The converted string.
     """
     return re.sub(r"([a-z0-9]+)([A-Z])", r"\1_\2", value).lower()
+
+
+def lowercase_to_pascal(value: str) -> str:
+    """
+    Converts a string from lower-case underscore separated strings into pascal case.
+    e.g. pascal_case => pascalCase.
+    Note: K8s API returns pascal cased strings, but in Python we use lower-cased strings with underscores instead.
+    :param value: The string to be converted.
+    :return: The converted string.
+    """
+    return re.sub(r"([a-z0-9]+)_([a-z])", lambda m: m.group(1) + m.group(2).upper(), value)
 
 
 class Field:
@@ -74,12 +85,19 @@ class EmbeddedField(Field):
 
     def parse(self, value: Dict[str, any]):
         if isinstance(value, dict):
-            # K8s API returns pascal cased strings, but we use lower-cased strings with underscores instead.
-            values = {pascal_to_lowercase(field_name): field_value for field_name, field_value in value.items()}
-            value = self.field_type(**values)
+            try:
+                # K8s API returns pascal cased strings, but we use lower-cased strings with underscores instead.
+                values = {pascal_to_lowercase(field_name): field_value for field_name, field_value in value.items()}
+                value = self.field_type(**values)
+            except TypeError as err:
+                raise ValueError("Invalid values passed to field {}: {}. Received {}."
+                                 .format(self.field_type.__name__, err, value))
         return super().parse(value)
 
-    def to_dict(self, value) -> Dict[str, any]:
+    def to_dict(self, value) -> Optional[Dict[str, any]]:
+        self.validate(value)
+        if value is None or isinstance(value, Field):
+            return None
         return {k: v for k, v in value.to_dict().items() if v is not None}
 
 

--- a/tests/services/TestKubernetesService.py
+++ b/tests/services/TestKubernetesService.py
@@ -423,6 +423,19 @@ class TestKubernetesService(TestCase):
         self.assertEqual(expected_calls, client_mock.mock_calls)
         self.assertEqual(client_mock.AppsV1beta1Api().create_namespaced_stateful_set.return_value, result)
 
+    def test_createStatefulSet_no_optional_fields(self, client_mock):
+        service = KubernetesService()
+        client_mock.reset_mock()
+        del self.cluster_dict["spec"]["mongodb"]["cpu_limit"]
+        del self.cluster_dict["spec"]["mongodb"]["memory_limit"]
+        self.cluster_object = V1MongoClusterConfiguration(**self.cluster_dict)
+
+        expected_calls = [call.AppsV1beta1Api().create_namespaced_stateful_set(self.namespace, self.stateful_set)]
+
+        result = service.createStatefulSet(self.cluster_object)
+        self.assertEqual(expected_calls, client_mock.mock_calls)
+        self.assertEqual(client_mock.AppsV1beta1Api().create_namespaced_stateful_set.return_value, result)
+
     def test_updateStatefulSet(self, client_mock):
         service = KubernetesService()
         client_mock.reset_mock()


### PR DESCRIPTION
Fixing issue with default for fields in the stateful sets. If CPU or memory was not given, the following error was happening:
```
AttributeError: 'StringField' object has no attribute 'swagger_types'
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:209)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at <listcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:193)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:193)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at <dictcomp> (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at sanitize_for_serialization (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:213)
at __call_api (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:144)
at call_api (/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py:321)
at create_namespaced_stateful_set_with_http_info (/usr/local/lib/python3.6/site-packages/kubernetes/client/apis/apps_v1beta1_api.py:471)
at create_namespaced_stateful_set (/usr/local/lib/python3.6/site-packages/kubernetes/client/apis/apps_v1beta1_api.py:386)
at createStatefulSet (/usr/src/app/mongoOperator/services/KubernetesService.py:240)
at createResource (/usr/src/app/mongoOperator/helpers/StatefulSetChecker.py:27)
at checkResource (/usr/src/app/mongoOperator/helpers/BaseResourceChecker.py:53)
at checkCluster (/usr/src/app/mongoOperator/helpers/ClusterChecker.py:123)
at checkExistingClusters (/usr/src/app/mongoOperator/helpers/ClusterChecker.py:66)
at run_forever (/usr/src/app/mongoOperator/MongoOperator.py:30)